### PR TITLE
Add delete tweet functionality and spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   # Guard::RSpec automatically run your specs (much like autotest)
   gem 'guard-rspec', require: false
+  # Guard::LiveReload automatically reloads your browser when 'view' files are modified.
+  gem 'guard-livereload', '~> 2.5', '>= 2.5.2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,11 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
     erubi (1.6.0)
+    eventmachine (1.2.3)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -85,10 +89,16 @@ GEM
       shellany (~> 0.0)
       thor (>= 0.18.1)
     guard-compat (1.2.1)
+    guard-livereload (2.5.2)
+      em-websocket (~> 0.5)
+      guard (~> 2.8)
+      guard-compat (~> 1.0)
+      multi_json (~> 1.8)
     guard-rspec (4.7.3)
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    http_parser.rb (0.6.0)
     i18n (0.8.1)
     jbuilder (2.6.4)
       activesupport (>= 3.0.0)
@@ -242,6 +252,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   factory_girl_rails
+  guard-livereload (~> 2.5, >= 2.5.2)
   guard-rspec
   jbuilder (~> 2.5)
   jquery-rails

--- a/Guardfile
+++ b/Guardfile
@@ -68,3 +68,42 @@ guard :rspec, cmd: "bundle exec rspec" do
     Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
   end
 end
+
+guard 'livereload' do
+  extensions = {
+    css: :css,
+    scss: :css,
+    sass: :css,
+    js: :js,
+    coffee: :js,
+    html: :html,
+    png: :png,
+    gif: :gif,
+    jpg: :jpg,
+    jpeg: :jpeg,
+    # less: :less, # uncomment if you want LESS stylesheets done in browser
+  }
+
+  rails_view_exts = %w(erb haml slim)
+
+  # file types LiveReload may optimize refresh for
+  compiled_exts = extensions.values.uniq
+  watch(%r{public/.+\.(#{compiled_exts * '|'})})
+
+  extensions.each do |ext, type|
+    watch(%r{
+          (?:app|vendor)
+          (?:/assets/\w+/(?<path>[^.]+) # path+base without extension
+           (?<ext>\.#{ext})) # matching extension (must be first encountered)
+          (?:\.\w+|$) # other extensions
+          }x) do |m|
+      path = m[1]
+      "/assets/#{path}.#{type}"
+    end
+  end
+
+  # file needing a full reload of the page anyway
+  watch(%r{app/views/.+\.(#{rails_view_exts * '|'})$})
+  watch(%r{app/helpers/.+\.rb})
+  watch(%r{config/locales/.+\.yml})
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :authenticate_user!, except: [:index]
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,5 +1,7 @@
 class TweetsController < ApplicationController
 
+  before_action :authenticate_user!
+
   def index
     @tweets = Tweet.all
   end
@@ -10,11 +12,13 @@ class TweetsController < ApplicationController
 
   def create
     @tweet = current_user.tweets.build(tweet_params)
+
     if @tweet.save
       redirect_to tweets_path
     else
       render :new
     end
+
   end
 
   def edit
@@ -28,10 +32,14 @@ class TweetsController < ApplicationController
 
   def update
     @tweet = Tweet.find(params[:id])
-
     @tweet.update(tweet_params)
     redirect_to tweets_path
+  end
 
+  def destroy
+    @tweet = Tweet.find(params[:id])
+    @tweet.destroy
+    redirect_to tweets_path
   end
 
   private

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome! </p>
+<h1>Welcome to our twitter clone! </h1>
 
 <ul>
 <% @tweets.each do |tweet| %>
@@ -8,6 +8,8 @@
 
     <% if current_user.id == tweet.user.id %>
       <%= link_to "Edit", edit_tweet_path(tweet) %>
+      <%= link_to "Delete", tweet_path(tweet), method: :delete %>
+      <!-- , data: { confirm: "Are you sure you wish to permanently delete this tweet?" } %> -->
     <% end %>
 
   </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resources :tweets, only: [ :index, :new, :create, :edit, :update ]
-
   root "tweets#index"
+
+  resources :tweets, except: [ :show ]
 
 end

--- a/spec/controllers/tweets_controller_spec.rb
+++ b/spec/controllers/tweets_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe TweetsController, type: :controller do
 
   let(:user) { create(:user) }
+
   before { sign_in user }
 
   describe 'GET #index' do
@@ -67,6 +68,17 @@ RSpec.describe TweetsController, type: :controller do
     before { put :update, params: { id: tweet, tweet: { text: tweet.text + 'Edited' } } }
 
     it { expect(Tweet.find(tweet.id).text.last(6)).to eq('Edited') }
+    it { expect(response).to redirect_to tweets_path }
+
+  end
+
+  describe 'DELETE #destroy' do
+
+    let(:tweet) { create(:tweet, user: user) }
+
+    before { delete :destroy, params: { id: tweet } }
+
+    it { expect(Tweet.count).to eq(0) }
     it { expect(response).to redirect_to tweets_path }
 
   end


### PR DESCRIPTION
This PR makes the following changes:

- Adds livereload guard plugin
- Adds delete functionality to tweets that belong to user
- Adds pending delete confirmation (does not pass rspec controller test for `:delete` if added)
- Adds controller spec tests for delete (passes if no confirmation dialog is in place)

Please review! Thanks :balloon: 